### PR TITLE
Refactor docs to one sentence per line

### DIFF
--- a/docs/admin/deployment-guide.rst
+++ b/docs/admin/deployment-guide.rst
@@ -3,45 +3,34 @@ How to deploy an application
 ############################
 
 
-In UNICEF - Office of Innovation team, we use `Azure Web Apps`_ to deploy our
-applications to the cloud.
+In the UNICEF Office of Innovation team, we use `Azure Web Apps`_ to deploy our applications to the cloud.
 
-This guide will walk you through the deployment process of a WebApp in the
-Azure environment. At the end of this guide you will be able to develop, tag
-and deploy the tagged version of the application to the azure servers.
+This guide will walk you through the deployment process of a WebApp in the Azure environment.
+At the end of this guide you will be able to develop, tag and deploy the tagged version of the application to the azure servers.
 
 
 ***************************************
 Create a feature branch for development
 ***************************************
 
-While in development, it is useful to make all of your changes in a feature 
-branch named accordingly to the task.
+While in development, it is useful to make all of your changes in a feature branch named accordingly to the task.
 
-For example, if we want to implement a new feature to show information about 
-the country the user clicked in, we could name the branch accordingly to this 
-task using the command below:
+For example, if we want to implement a new feature to show information about the country the user clicked in, we could name the branch accordingly to this task using the command below:
 
 .. code:: bash
 
     git checkout -b show_country_information
 
-
-We can implement our features in this branch and submit a Pull Request to 
-merge it into the master branch of the app.
-
+We can implement our features in this branch and submit a Pull Request to merge it into the master branch of the app.
 
 Create a tag
 ============
 
-Once your changes get merged into master, we can create a tag for the current 
-version of the application. Make sure to name the tag accordingly with the 
-project's convention and following the `semantic versioning`_ rules.
+Once your changes get merged into master, we can create a tag for the current version of the application.
+Make sure to name the tag accordingly with the project's convention and following the `semantic versioning`_ rules.
 
-For example, let's suppose that you made a simple fix in the application and 
-your changes just got merged from the branch "fix_bug_61" into master. In this 
-project, tags are named using the convention "vX.X.X" and the last tag is 
-"v1.1.1".
+For example, suppose you made a simple fix in the application and your changes just got merged from the branch "fix_bug_61" into master.
+In this project, tags are named using the convention "vX.X.X" and the last tag is "v1.1.1".
 
 Since your fix is a `patch`_, you can create the tag "v1.1.2" with the command 
 
@@ -49,95 +38,72 @@ Since your fix is a `patch`_, you can create the tag "v1.1.2" with the command
 
     git tag v1.1.2
 
-Always remember to push the tag to the public repository to make others aware 
-of the current project version. You can push your tags to the public 
-repository with the command
+Always remember to push the tag to the public repository to make others aware of the current project version.
+You can push your tags to the public repository with the command.
 
 .. code:: bash
 
     git push origin master --tags
 
 
-
 *************************
 Deploying the application
 *************************
 
+After our changes get merged into master, we can deploy the application to Azure.
 
-After our changes get merged into master, we can deploy the application to 
-Azure.
+Each UNICEF's application in Azure have two main deployment slots: production and staging.
 
-Each UNICEF's application in Azure have two main deployment slots: production 
-and staging.
-
-In the production slot lies the code that you can see in your browser, the 
-application as it is, available for the final user.
+In the production slot lies the code that you can see in your browser, the application as it is, available for the final user.
 
 The staging slot contains the code preparing to be released to production. 
-Once your code is in this slot you can take a look in a private url to see how 
-your code will respond in production.
+Once your code is in this slot you can take a look in a private url to see how your code will respond in production.
 
-If everything looks correct in staging, you can swap the code in production 
-with the code in the staging slot to make your changes available for all users.
-
+If everything looks correct in staging, you can swap the code in production with the code in the staging slot to make your changes available for all users.
 
 Adding Azure remote for repository
 ==================================
 
+The first thing we need to do is add the staging remote to our local git repository.
 
-The first thing we need to do is add the staging remote to our local git 
-repository.
-
-Within the project directory, you can add the stagin remote for the project 
-issuing the command below.
+Within the project directory, you can add the stagin remote for the project issuing the command below.
 
 .. code:: bash
 
     git remote add staging https://<username>@<project-name>-staging.scm.azurewebsites.net:443/<project-name>.git
 
-Make sure to change <project-name> with the project name you are working on and
-<username> for your username set in the deployment credentials in Azure.
-
+Make sure to change <project-name> with the project name you are working on and <username> for your username set in the deployment credentials in Azure.
 
 Pushing changes to the staging slot
 ===================================
 
-
-You can push changes to the staging repository issuing the command below
+Push changes to the staging repository issuing the command below
 
 .. code:: bash
 
     git push staging master
 
-This command will push the current version in your master branch to staging in 
-azure.
+This command will push the current version in your master branch to staging in azure.
 
-To push a specific tag to azure you can run the command
+To push a specific tag to Azure, run:
 
 .. code:: bash
 
     git push staging tagname:master
 
-Make sure to replace "tagname" with the tag you want to push to azure.
-
+Replace "tagname" with the tag you want to push to azure.
 
 Swap staging to production (Web)
 ================================
 
-The last step to make your changes available to the public is swap the staging 
-environment with the production environment.
+The last step to make your changes available to the public is swap the staging environment with the production environment.
 
-Once your code is working properly in the staging environment, you can swap it 
-with production. Swaping those slots means that the code in the staging 
-environment now answers for the production environment and the code in the 
-production environment now lives in the staging environment.
+Once your code is working properly in the staging environment, you can swap it with production.
+Swapping those slots means that the code in the staging environment now answers for the production environment and the code in the production environment now lives in the staging environment.
 
-If a bug was introduced in your changes and it was not caught in the staging 
-environment and is now in the production environment, all you have to do to 
-revert it to the last working version of the application is to swap it again.
+If a bug was introduced in your changes and it was not caught in the staging environment and is now in the production environment, all you have to do to revert it to the last working version of the application is to swap it again.
 
-To make the swap, go to the `Azure Panel`_ > App Services, find the project 
-you are working on and select it.
+To make the swap, go to the `Azure Panel`_ > App Services, find the project you are working on and select it.
 
 .. image:: ../_static/deployguide-appservices.png
 
@@ -145,22 +111,18 @@ In the overview section you will find the "Swap" button, you can click in it.
 
 .. image:: ../_static/deployguide-swap.png
 
-Make sure to select in the Swap panel "staging" as source and "production" as 
-destination.
+Make sure to select in the Swap panel "staging" as source and "production" as destination.
 
 .. image:: ../_static/deployguide-swap-menu.png
 
 Click OK to make the swap. You will get a notification once it finishes.
 
-To replace your changes for the last working version of the application, just 
-repeat this procedure.
-
+To replace your changes for the last working version of the application, just repeat this procedure.
 
 Swap staging to production (CLI)
 ================================
 
-If you have the right permissions in place you can make the swap using the 
-`Azure CLI`_.
+If you have the right permissions in place you can make the swap using the `Azure CLI`_.
 
 To do this, make sure you are in the ASM mode running
 

--- a/docs/administrative-boundaries.rst
+++ b/docs/administrative-boundaries.rst
@@ -2,70 +2,70 @@
 Administrative boundaries
 #########################
 
-UNICEF uses **administrative boundaries** (or administrative areas) to
-define geographic areas in MagicBox and related projects. Administrative
-boundaries (ABs) extend the concepts of a country, state, or region.
+UNICEF uses **administrative boundaries** (or administrative areas) to define geographic areas in MagicBox and related projects.
+Administrative boundaries (ABs) extend the concepts of a country, state, or region.
 Examples of an administrative boundary may be…
 
--  Country
--  State
--  Province
--  County
--  Municipality
--  And more…
+- Country
 
-ABs come from `GADM <http://gadm.org/>`__ and the `Humanitarian Data
-Exchange <https://data.humdata.org/>`__ (HumData), databases of global
-administrative areas. In addition, more ABs may come from other sources
-like municipal governments. These databases make it easier to work with
-this data in GIS or related software.
+- State
+
+- Province
+
+- County
+
+- Municipality
+
+- And more…
+
+ABs come from `GADM <http://gadm.org/>`__ and the `Humanitarian Data Exchange <https://data.humdata.org/>`__ (HumData), databases of global administrative areas.
+In addition, more ABs may come from other sources like municipal governments.
+These databases make it easier to work with this data in GIS or related software.
 
 
 ******
 Levels
 ******
 
-Levels are a hierarchy system to explain different concepts of
-administrative boundaries. For example, a city may belong to a
-municipality, which belongs to a country. Levels help us explain this
-hierarchy.
+Levels are a hierarchy system to explain different concepts of administrative boundaries.
+For example, a city may belong to a municipality, which belongs to a country.
+Levels help us explain this hierarchy.
 
 UNICEF uses this system of levels:
 
--  **Level 0**: Countries
--  **Level 1**: States
--  **Level 2**: Counties
--  **Level 3**: Municipalities
--  And so on…
+- **Level 0**: Countries
+
+- **Level 1**: States
+
+- **Level 2**: Counties
+
+- **Level 3**: Municipalities
+
+- And so on…
 
 
 ***************
 Why we use them
 ***************
 
-Different definitions of geographic areas by different nations makes
-worldwide geographic mapping a challenge. Not everyone uses the same
-names for regions. In MagicBox projects, each region, or **shape**, is
-assigned an ``admin_id``.
+Different definitions of geographic areas by different nations makes worldwide geographic mapping a challenge.
+Not everyone uses the same names for regions.
+In MagicBox projects, each region, or **shape**, is assigned an ``admin_id``.
 
-An ``admin_id`` is an interpretation of a political border for a
-specific time. They point to a specific shape in a shapefile that
-represents an individual country. Time is a part of the admin ID to
-ingest historical data. For example, mobility or temperature might
-require a series from an earlier date where a region was known by a
-different name.
+An ``admin_id`` is an interpretation of a political border for a specific time.
+They point to a specific shape in a shapefile that represents an individual country.
+Time is a part of the admin ID to ingest historical data.
+For example, mobility or temperature might require a series from an earlier date where a region was known by a different name.
 
-See the following example of an AB for Afghanistan, with an
-``admin_id``.
+See the following example of an AB for Afghanistan, with an ``admin_id``.
 
 .. figure:: https://cdn-images-1.medium.com/max/800/1*wAatd2Qiu5vXYmatpVCcmg.png
    :alt: Example of an administrative boundary for Afghanistan
 
    Example of an administrative boundary for Afghanistan
 
-To understand where ``afg_1_11_102-gadm2–8`` points to, note that
-Afghanistan has three **levels** of administrative boundaries. The
-``admin_id`` has three integers, one per admin level:
+To understand where ``afg_1_11_102-gadm2–8`` points to, note that Afghanistan has three **levels** of administrative boundaries.
+The ``admin_id`` has three integers, one per admin level:
 
 .. figure:: https://cdn-images-1.medium.com/max/800/1*hGHSrnLcyXdPDDvXje_UsQ.png
    :alt: Afghanistan has three levels of administrative boundaries
@@ -80,8 +80,7 @@ Naming string explained
 First integer
 =============
 
-The first integer is ``1`` because Afghanistan is the first country in
-GADM's database.
+The first integer is ``1`` because Afghanistan is the first country in GADM's database.
 
 .. figure:: https://cdn-images-1.medium.com/max/800/1*9WTComzFpXK2yUk8lNXg8A.png
    :alt: The first few countries in GADM's database
@@ -103,12 +102,13 @@ Afghanistan has 34 shapes at level one and 320 shapes in level two.
 Putting it together
 ===================
 
-Thus, ``afg_1_11_102-gadm2–8`` indicates any population value attached
-to it is related to:
+Thus, ``afg_1_11_102-gadm2–8`` indicates any population value attached to it is related to:
 
--  First country in the gadm collection
--  11th shape in the admin level 1 shapefile
--  102nd shape in the admin level 2 shapefile
+- First country in the gadm collection
+
+- 11th shape in the admin level 1 shapefile
+
+- 102nd shape in the admin level 2 shapefile
 
 .. figure:: https://cdn-images-1.medium.com/max/800/1*k6TaJ4I0zk39f24yG_d_WQ.png
    :alt: Putting it together: What the admin ID represents

--- a/docs/data/data-ingesting.rst
+++ b/docs/data/data-ingesting.rst
@@ -2,26 +2,25 @@
 Ingesting data into MagicBox
 ############################
 
-Importing new data sets to MagicBox is important for expanding coverage and
-how we retrieve new data insights. This document explains how we ingest and
-import new data to MagicBox.
+Importing new data sets to MagicBox is important for expanding coverage and how we retrieve new data insights.
+This document explains how we ingest and import new data to MagicBox.
 
 
 *********************
 School data ingestion
 *********************
 
-Data for schools comes in CSV files with a specific naming scheme. We developed
-a Ruby on Rails-based CRUD [#]_ application, `Project Connect`_ to ingest this
-data.
+Data for schools comes in CSV files with a specific naming scheme.
+We developed a Ruby on Rails-based CRUD [#]_ application, `Project Connect`_ to ingest this data.
 
 There are two admin interfaces for Rails applications:
 
 - Rails Admin
+
 - Active Admin
 
-Active Admin has an `import plugin`_ for uploading CSVs with
-``before_batch_import`` support. We chose Active Admin for this reason.
+Active Admin has an `import plugin`_ for uploading CSVs with ``before_batch_import`` support.
+We chose Active Admin for this reason.
 
 .. image:: /_static/data-ingesting-import-csv-rails.png
 
@@ -30,30 +29,31 @@ Active Admin has an `import plugin`_ for uploading CSVs with
 School data database
 ********************
 
-MagicBox needed a database to manage large amounts of school data and process it
-quickly. To do this, MagicBox uses a relational database, `PostgreSQL`_, to
-store data. PostgreSQL was chosen because it was used in a tutorial for building
-a similar use case as ours (thus, a relational database is not a "married"
-idea).
+MagicBox needed a database to manage large amounts of school data and process it quickly.
+To do this, MagicBox uses a relational database, `PostgreSQL`_, to store data.
+PostgreSQL was chosen because it was used in a tutorial for building a similar use case as ours (thus, a relational database is not a "married" idea).
 
-All school data is stored in a single table named ``schools``. This keeps things
-simple at the expense of some repeated values in the database.
+All school data is stored in a single table named ``schools``.
+This keeps things simple at the expense of some repeated values in the database.
 
 Inserted data
 =============
 
-When data is imported, new data is inserted alongside the imported data. Four
-new types of important data are added:
+When data is imported, new data is inserted alongside the imported data.
+Four new types of important data are added:
 
 - Provider / owner of school CSV data
+
 - Organization that received school data
+
 - Identity of uploader
+
 - If uploader chooses to remain private
 
 .. image:: /_static/data-ingesting-added-columns.png
 
-These values are not included with the data. We use the ``before_batch_import``
-hook in Active Admin to parse file names, insert this data, and assign values.
+These values are not included with the data.
+We use the ``before_batch_import`` hook in Active Admin to parse file names, insert this data, and assign values.
 
 .. figure:: /_static/data-ingesting-code-inserting-data.png
 

--- a/docs/data/data-querying.rst
+++ b/docs/data/data-querying.rst
@@ -2,18 +2,21 @@
 Querying MagicBox data
 ######################
 
-The MagicBox API (`magicbox-open-api`_) serves different sets of data through
-its API. Currently, five datasets are available.
+The MagicBox API (`magicbox-open-api`_) serves different sets of data through its API.
+Currently, five datasets are available.
 
 - Cases
+
 - Mobility
+
 - Mosquitoes
+
 - Population
+
 - Schools
 
-The benefit of querying this data is to analyze and cross different data sets
-together. For example, this is done in `magicbox-maps`_, where population and
-mosquito prevelance data are crossed together.
+The benefit of querying this data is to analyze and cross different data sets together.
+For example, this is done in `magicbox-maps`_, where population and mosquito prevelance data are crossed together.
 
 This document explains how the API works but does not document how to use it.
 For more information on using the API, see the `magicbox-open-api`_ repository.
@@ -55,38 +58,45 @@ Population
 Schools
 *******
 
-The MagicBox API also serves data about schools. The public repositories contain
-sample data from private data sets; however, in the interest of the privacy and
-safety of the schools, the full data sets are kept private.
+The MagicBox API also serves data about schools.
+The public repositories contain sample data from private data sets.
+However, in the interest of the privacy and safety of the schools, the full data sets are kept private.
 
 How we do it
 ============
 
-There are three endpoints for querying school data. They serve the following
-data:
+There are three endpoints for querying school data.
+They serve the following data:
 
 #. List of countries with school data
+
 #. Schools in a country
+
 #. Specific school data by ID value
 
-The first endpoint returns a comma-seperated list of country codes. There is
-available data about schools in the countries returned in the list.
+The first endpoint returns a comma-seperated list of country codes.
+There is available data about schools in the countries returned in the list.
 
 The second endpoint returns an array of arrays, where
 
-- First array returns column names (e.g. ``lat``, ``lon``,
-  ``speed_connectivity``, ``type_connectivity``)
+- First array returns column names (e.g. ``lat``, ``lon``, ``speed_connectivity``, ``type_connectivity``)
 - Subsequent arrays return values for school records
 
-The third endpoint returns column values from a specific school, as selected by
-its ID number. Some of the values available are listed below:
+The third endpoint returns column values from a specific school, as selected by its ID number.
+Some of the values available are listed below:
 
 - Address
+
 - Network connectivity
+
 - Number of teachers
+
 - Number of students
+
 - If electricity is available
+
 - If running water is available
+
 - And more
 
 .. figure:: /_static/data-querying-school-data.png
@@ -101,7 +111,9 @@ Caveats
 There are some caveats with querying the MagicBox API.
 
 - Cannot specify or limit columns included in response
+
 - Cannot request values where value is null
+
 - Cannot use operators (e.g. greater than, less than, etc.)
 
 

--- a/docs/data/data-validation.rst
+++ b/docs/data/data-validation.rst
@@ -2,12 +2,10 @@
 Data validation
 ###############
 
-Data validation ensures correct and consistent data is processed and aggregated
-for use in MagicBox. The validated data is used by implementations of the
-MagicBox API, such as `magicbox-maps`_.
+Data validation ensures correct and consistent data is processed and aggregated for use in MagicBox.
+The validated data is used by implementations of the MagicBox API, such as `magicbox-maps`_.
 
-This article explains how we verify values, identify duplicates, and merge
-multiple records into one.
+This article explains how we verify values, identify duplicates, and merge multiple records into one.
 
 
 ************
@@ -18,12 +16,11 @@ How we do it
 
    How `magicbox-latlong-admin-server`_ validates coordinate pairs
 
-Data validation is performed by `magicbox-latlong-admin-server`_. The server
-verifies a pair of latitude / longtitude coordinates are located within the
-country indicated by the beginning of a file name.
+Data validation is performed by `magicbox-latlong-admin-server`_.
+The server verifies a pair of latitude / longtitude coordinates are located within the country indicated by the beginning of a file name.
 
-The `data validation program`_ processes every ten minutes as a cron job. It
-runs a programatic version of this query:
+The `data validation program`_ processes every ten minutes as a cron job.
+It runs a programatic version of this query:
 
 .. code-block:: sql
    :emphasize-lines: 2
@@ -37,11 +34,11 @@ runs a programatic version of this query:
 Adding new attributes
 =====================
 
-After the data is validated, the `magicbox-latlong-admin-server`_ updates
-attributes for some data. The attributes are only added if the engine returns an
-admin area ID for the target country (see :doc:`../administrative-boundaries`).
+After the data is validated, the `magicbox-latlong-admin-server`_ updates attributes for some data.
+The attributes are only added if the engine returns an admin area ID for the target country (see :doc:`../administrative-boundaries`).
 
 #. ``date_geo_validated``: To ``CURRENT_TIMESTAMP``
+
 #. ``coords_within_country``: true or false
 
 
@@ -50,11 +47,10 @@ Why we do it
 ************
 
 Some CSV files we import and aggregate contain tens of thousands of records.
-Data validation is an expensive operation. We chose not to verify each school's
-coordinates in the ``before_batch_import`` hook for this reason.
+Data validation is an expensive operation.
+We chose not to verify each school's coordinates in the ``before_batch_import`` hook for this reason.
 
-Instead, we opted for the `data validation program`_ to run as a cron job every
-ten minutes to accomplish this.
+Instead, we opted for the `data validation program`_ to run as a cron job every ten minutes to accomplish this.
 
 
 .. _`magicbox-maps`: https://github.com/unicef/magicbox-maps

--- a/docs/data/data-visualization.rst
+++ b/docs/data/data-visualization.rst
@@ -2,23 +2,20 @@
 Data visualization
 ##################
 
-MagicBox is a full-stack application. While the back-end API
-(`magicbox-open-api`_) serves the data and makes it available for querying, the
-`magicbox-maps`_ application visualizes the data inside a world map.
+MagicBox is a full-stack application.
+While the back-end API (`magicbox-open-api`_) serves the data and makes it available for querying, the `magicbox-maps`_ application visualizes the data inside a world map.
 
 
 ************
 How we do it
 ************
 
-`magicbox-maps`_ draws the plot points using OpenStreetMap `Leaflet`_ and
-`WebGL`_. WebGL allows us to render up to `16 million clickable points`_ at
-once.
+`magicbox-maps`_ draws the plot points using OpenStreetMap `Leaflet`_ and `WebGL`_.
+WebGL allows us to render up to `16 million clickable points`_ at once.
 
-To do this inside of a `React`_ application like ``magicbox-maps``, we created
-`react-webgl-leaflet`_. This React module enables us to render several plot
-points simultaneously, like we use for the school mapping data. Every school is
-represented with a unique, clickable point.
+To do this inside of a `React`_ application like ``magicbox-maps``, we created `react-webgl-leaflet`_.
+This React module enables us to render several plot points simultaneously, like we use for the school mapping data.
+Every school is represented with a unique, clickable point.
 
 .. figure:: /_static/data-visualization-webgl.png
 
@@ -31,10 +28,10 @@ This is currently used for `magicbox-maps`_.
 Why we do it
 ************
 
-Originally, we began using `Leaflet`_ markers. This worked well for Mauritania
-with 2,936 schools. However, when we moved to Colombia with 49,020 schools,
-performance took a significant hit. We experimented with a few other options,
-like heatmaps and clustering.
+Originally, we began using `Leaflet`_ markers.
+This worked well for Mauritania with 2,936 schools.
+However, when we moved to Colombia with 49,020 schools, performance took a significant hit.
+We experimented with a few other options, like heatmaps and clustering.
 
 .. image:: /_static/data-visualization-method-comparison.png
 


### PR DESCRIPTION
This is a borrowed convention from AsciiDoc that I fell in love. Writing docs
as one sentence per line is weird as a writer, but it makes a PR against docs
easier to read and understand. The diff will align sentences side-by-side. So
this commit brings our existing docs into this format.

Some of the docs up to this point were already written this way, so this also
makes everything consistent too.