### PR TITLE
Write about CI & Code health checks in the Docs

### DIFF
--- a/docs/admin/github-workflow.rst
+++ b/docs/admin/github-workflow.rst
@@ -259,11 +259,9 @@ Before following the steps below to activate Code Climate for a new repository, 
   after_script:
     - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
-  The code above tells Code Climate to run and report on test coverage scores every time Travis CI runs checks for a new pull request.
-  Code Climate, however, does not generate test coverage results itself - it reads output from a supported testing framework. / it relies on third party tools to generate local test coverage reports, as said `here <https://docs.codeclimate.com/docs/configuring-test-coverage#section-requirements>`_.
-  We, therefore, need to install a testing framework - in our case, that would be `lcov <http://ltp.sourceforge.net/coverage/lcov.php>`_ since we code in JavaScript.
-  ................//PICK UP HERE AFTER INSTALLING Istanbul (?) FOR MAPs-PROTOTYPE.
-
+ The code above tells Code Climate to run and report on test coverage scores every time Travis CI runs checks for a new pull request.
+ Code Climate, however, does not generate test coverage results itself - it reads output from a supported testing framework, which usually are third-party tools, as said `here <https://docs.codeclimate.com/docs/configuring-test-coverage#section-requirements>`_.
+ We, therefore, need to `set up a testing framework`_ in our code, which is covered below.
 
 Deeper reads:
 
@@ -276,6 +274,13 @@ Deeper reads:
  4. The last step is to embed the **maintainability and test coverage badges** to GitHub.
  Head to your repository on Code Climate and click on *Repo Settings* > *Badges*.
  Select the format of your choice and copy that code snippet to the top of the repository's README, just under the repository's name. (This `guide <https://docs.codeclimate.com/docs/overview#section-badges>`_ has good screenshots to illustrate this step.)
+
+.. _set-up-testing-framework:
+
+Set up a testing framework
+===========================
+
+.. note:: To be written.
 
 ***********************************
 How to maintain a GitHub repository

--- a/docs/admin/github-workflow.rst
+++ b/docs/admin/github-workflow.rst
@@ -158,14 +158,14 @@ Below is how you can add this service to a new repository:
     directories:
       - "node_modules"
 
- *(If these steps do not make sense, refer to this `Getting Started guide <https://docs.travis-ci.com/user/getting-started/>`_ by Travis CI.)*
+ If these steps do not make sense, refer to this `Getting Started guide <https://docs.travis-ci.com/user/getting-started/>`_ by Travis CI.
 
  5. The last step is to add the Travis CI badge to the repository's README.
  Browse to the Travis CI page of the repository - the URL probably looks like this: ``htps://travis-ci.com/unicef/the-repo-of-interest``.
  Find the status symbol next to your repository's name (the little bar to the right of the Octocat).
  In the pop-up window, click the drop-down menu to select Markdown, then copy the generated code block.
  Paste it to the top of your README file, just under the repository's name.
- *If unclear, see `this guide <https://docs.travis-ci.com/user/status-images/>`_*
+ If unclear, see `this guide <https://docs.travis-ci.com/user/status-images/>`_.
 
 .. _set-up-code-health-checks:
 
@@ -267,9 +267,9 @@ Deeper reads:
 
 - If you don't have admin access to a repository but still want to track its detailed code health analysis, go to its README on GitHub, click on its Maintainability badge to open its Code Climate report, and hit *Star* to add this repository to your Code Climate dashboard. If unclear, `see this guide <https://docs.codeclimate.com/docs/adding-an-oss-repo-to-your-dashboard#section-adding-an-oss-repo-to-your-dashboard>`_.
 
-- If you are a core developer or maintainer, read this article to make better use of Code Climate in your pull request workflow: https://docs.codeclimate.com/docs/workflow
+- If you are a core developer or maintainer, `read this article <https://docs.codeclimate.com/docs/workflow>`_ to make better use of Code Climate in your pull request workflow.
 
-- Advanced features with *review comments*: https://docs.codeclimate.com/docs/github-pull-requests#section-pull-request-review-comments
+- Explore advanced features with `review comments <https://docs.codeclimate.com/docs/github-pull-requests#section-pull-request-review-comments>`_.
 
  4. The last step is to embed the **maintainability and test coverage badges** to GitHub.
  Head to your repository on Code Climate and click on *Repo Settings* > *Badges*.

--- a/docs/admin/github-workflow.rst
+++ b/docs/admin/github-workflow.rst
@@ -117,7 +117,8 @@ Every repository's issue and pull request labels are found under the *Issues* ta
 
    Click the *Labels* button towards the right of the search bar
 
-A good example of labels is `here <https://github.com/unicef/magicbox/labels>`_ on the `unicef/magicbox`_ repository. To view the color code for a given label, click the *Edit* on its row.
+A good example of labels is `here <https://github.com/unicef/magicbox/labels>`_ on the `unicef/magicbox`_ repository.
+To view the color code for a given label, click the *Edit* on its row.
 
 Not all of these labels will be helpful for a new project.
 Take ones that make sense, and make new labels specific to the project, if needed.
@@ -129,22 +130,23 @@ Set up continuous integration (CI)
 
 - `Why we need CI <https://github.com/unicef/magicbox/issues/6>`_
 
-After his research, Justin (`@jwflory <https://github.com/jwflory>`_) - one of our former interns - `decided <https://github.com/unicef/magicbox-aggregate-mobility/issues/11>`_ to select `Travis CI <https://travis-ci.com/>`_ for our repos.
-Below is how you can add this service to a repo:
+MagicBox repositories use `Travis CI <https://travis-ci.com/>`_ for continuous integration.
+Below is how you can add this service to a new repository:
 
- 1. Make sure you have the **admin access** to the repo.
- (New core developers can gain such access across multiple repositories if Mike (`@mikefab <https://github.com/mikefab>`_) or one of the people in charge adds them to the `MagicBox Admins team <https://github.com/orgs/unicef/teams/magicbox-admins/members>`_.)
+ 1. Make sure you have the **admin access** to the repository.
+ New core developers can gain such access across multiple repositories by joining the `MagicBox Admins team <https://github.com/orgs/unicef/teams/magicbox-admins/members>`_.
+ Contact Mike (`@mikefab <https://github.com/mikefab>`_) or one of the lead maintainers for this permission.
 
- 2. If you are not on Travis CI yet, browse to `travis-ci.com <https://travis-ci.com/>`_ and log in with your GitHub account.
- Along the way, you will have the option to add any repository to Travis CI.
+ 2. If you are not already on Travis CI, browse to `travis-ci.com <https://travis-ci.com/>`_ and log in with your GitHub account.
+ Along the way, you will see the option to add any repository to Travis CI.
  Select *Only select repositories* and choose ``unicef/<the-repo-of-interest>`` from the drop-down list.
- **NOTE**: As of 07/2018, we still go by handpicking repositories rather than adding every repository to Travis CI, although this policy might change in the future.
- Once you arrive at your Travis CI Profile page, you will see the list of all repositories currently under Travis CI tracking (whether from your personal account or the `@unicef <https://github.com/unicef>`_ GitHub account).
+ At the moment, we still handpick repositories to be monitored by Travis CI because not all repositories will need this service.
+ Once you arrive at your Travis CI Profile page, you will see a list of all repositories currently under Travis CI tracking, whether they belong to your personal account or the `@unicef <https://github.com/unicef>`_ GitHub account.
 
  3. Now go to the repository's main page on GitHub, click on the *Settings* tab, then select *Integrations & services* from the left-side menu.
  If everything is properly set up in the previous step, you should see Travis CI under *Installed GitHub Apps*.
 
- 4. Go to the root directory of the repository and add a new file called ``.travis.yml``.
+ 4. From the root directory of the repository on GitHub, add a new file called ``.travis.yml``.
  Place the following content in that file:
 
  .. code-block:: javascript
@@ -156,13 +158,14 @@ Below is how you can add this service to a repo:
     directories:
       - "node_modules"
 
- (If these steps do not make sense, refer to this `Getting Started guide <https://docs.travis-ci.com/user/getting-started/>`_ by Travis CI.)
+ *(If these steps do not make sense, refer to this `Getting Started guide <https://docs.travis-ci.com/user/getting-started/>`_ by Travis CI.)*
 
  5. The last step is to add the Travis CI badge to the repository's README.
- Go to the Travis CI page of the repository - the URL probably looks like this: ``htps://travis-ci.com/unicef/the-repo-of-interest``.
+ Browse to the Travis CI page of the repository - the URL probably looks like this: ``htps://travis-ci.com/unicef/the-repo-of-interest``.
  Find the status symbol next to your repository's name (the little bar to the right of the Octocat).
- Click on it to generate the code block you'll put into your README, by selecting Markdown from the second dropdown menu when the Status Image window pops up (if unclear, see `this guide <https://docs.travis-ci.com/user/status-images/>`_).
- Copy the code snippet and place it on top of your repository's README file, just under the repository's name.
+ In the pop-up window, click the drop-down menu to select Markdown, then copy the generated code block.
+ Paste it to the top of your README file, just under the repository's name.
+ *If unclear, see `this guide <https://docs.travis-ci.com/user/status-images/>`_*
 
 .. _set-up-code-health-checks:
 
@@ -170,21 +173,25 @@ Set up code health checks with Code Climate
 ============================================
 =======
 
-We use `Code Climate <https://codeclimate.com/>`_ for our projects.
+`Code Climate <https://codeclimate.com/>`_ is the chosen code health checker for MagicBox projects.
 This automated code review service runs checks whenever a pull request is made, helping contributors and maintainers identify issues before they get merged into the code base.
-While Travis CI also provides pre-merge checks, the analysis provided by Code Climate is less about whether or not the program will break and more about how maintainable and "clean" the code is - hence the term "code health."
-Examples of issues that Code Climate will bring up: code is too complex/hard to read and understand; code is duplicated; a function or a class is too long and should be refactored; issues raised by ESLint.
-Aside from that, Code Climate also scores test coverage.
-Having high test coverage means the code in that particular repository is of high quality.
+That makes it sound similar to Travis CI or other CI tools in general - they all perform pre-merge checks.
+The main difference is: one is more about the technical functionality of the code (*e.g. will my program crash?**) and the other considers how "clean" and maintainable the code is - hence the term "code health."
+Examples of issues that Code Climate could bring up: complex or hard-to-understand code; code duplicates; functions or classes that are too long and need refactoring; style issues raised by ESLint.
 
-Below is how you can add this service to a repository - make sure to gain **admin access** first.
+Aside from that, Code Climate automates and displays test coverage results.
+Having a high test coverage score is encouraged for any code repository, especially open source projects since the code quality will affect and be affected by a larger group of developers.
+Code Climate reads output from locally run tests or coverage tools like `lcov <http://ltp.sourceforge.net/coverage/lcov.php>`_, then displays the score alongside the analysis of other quality metrics.
+The score can be viewed via both the dashboard on Code Climate site and the README badge.
 
- 1. Sign into `Code Climate - Quality <https://codeclimate.com/dashboard>`_ if you're not on it yet.
- If it's your first time signing up, use your GitHub account.
+Before following the steps below to activate Code Climate for a new repository, make sure to gain **admin access** first.
+
+ 1. Sign into `Code Climate - Quality <https://codeclimate.com/dashboard>`_ if you are not on it yet.
+ If this is your first time signing up, use your GitHub account.
  (If you already have a Code Climate account and it is not **linked with your GitHub account**, follow `these instructions <https://docs.codeclimate.com/docs/linkingunlinking-my-github-user>`_ to set that up.)
  Select *Open Source* as you sign up and you can add the repository here.
  Handpick repositories rather than opting for *All repositories*.
- If you're already landing on your Code Climate dashboard, then you can always add new repositories by clicking on the button *Add a repository*.
+ If you are already on Code Climate, add new repositories by clicking on the button *Add a repository* from your Dashboard.
  (If all of this doesn't make sense, use this `guide from CodeClimate <https://docs.codeclimate.com/docs/open-source-free#section-adding-an-oss-github-repo-to-code-climate>`_.)
 
  2. Now Code Climate has started tracking your code, but you need a bit more set-up in order to interact with this service more actively.
@@ -197,7 +204,7 @@ Below is how you can add this service to a repository - make sure to gain **admi
   If this option is not available or nowhere to be seen, it could be because you have not installed the Code Climate GitHub app.
   In step 1, by signing up and linking your GitHub account, you have connected with Code Climate via OAuth authentication.
   Your GitHub repository now sees Code Climate as an OAuth app.
-  However, for Code Climate to automatically display the check status at each pull request, Code Climate needs to have access to your GitHub repository as a GitHub app.
+  However, to automatically display the check status at each pull request, Code Climate needs to have access to your GitHub repository as a GitHub app.
   Hence, head to `Code Climate GitHub app <https://github.com/apps/codeclimate>`_ to install it on *both* your personal account and the `@unicef <https://github.com/unicef>`_ GitHub account. You should install it on your personal account to utilize Code Climate power when you work in your own forks.
 
   b. **Set up Webhooks**:
@@ -222,9 +229,9 @@ Below is how you can add this service to a repository - make sure to gain **admi
    nodesecurity:
      enabled: true
 
-  This code, in addition to accessing the newest ESLint release possible (channel 4, see more here: https://docs.codeclimate.com/docs/eslint), specifies the file extensions that we want ESLint to analyze.
+  This code accesses the newest ESLint release possible (channel 4, see more here: https://docs.codeclimate.com/docs/eslint) and specifies the file extensions that we want ESLint to analyze.
 
- 3. We are not done yet since we also want **test coverage reporting**.
+ 3. By now, most quality metrics have been taken care of except for *test coverage reporting**.
  As said in point number 7 `here <https://docs.codeclimate.com/docs/github-pull-requests#section-show-me-how>`_, test coverage statuses are enabled by default when you enable Pull Request integration.
  However, the docs article also says you need to configure test coverage for the statuses to populate.
  Hence, go to your repository on Code Climate and navigate to *Repo Settings* > *Test coverage*.
@@ -252,6 +259,12 @@ Below is how you can add this service to a repository - make sure to gain **admi
     - ./cc-test-reporter before-build
   after_script:
     - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+
+  The code above tells Code Climate to run and report on test coverage scores every time Travis CI runs checks for a new pull request.
+  Code Climate, however, does not generate test coverage results itself - it reads output from a supported testing framework. / it relies on third party tools to generate local test coverage reports, as said `here <https://docs.codeclimate.com/docs/configuring-test-coverage#section-requirements>`_.
+  We, therefore, need to install a testing framework - in our case, that would be `lcov <http://ltp.sourceforge.net/coverage/lcov.php>`_ since we code in JavaScript.
+  ................//PICK UP HERE AFTER INSTALLING Istanbul (?) FOR MAPs-PROTOTYPE.
+
 
 Deeper reads:
 

--- a/docs/admin/github-workflow.rst
+++ b/docs/admin/github-workflow.rst
@@ -126,28 +126,26 @@ Take ones that make sense, and make new labels specific to the project, if neede
 
 Set up continuous integration (CI)
 ==================================
-After his research, @jwflory - one of our former interns - `decided <https://github.com/unicef/magicbox-aggregate-mobility/issues/11>`_ to select Travis CI for our repos. Below is how you are going to add this service to a repo:
 
-1. Make sure you have the admin access to the repo. (New core developers can gain such access across multiple repos if @mikefab or one of the people in charge adds them to the `MagicBox Admins team <https://github.com/orgs/unicef/teams/magicbox-admins/members>`_.)
+After his research, `@jwflory <https://github.com/jwflory>`_ - one of our former interns - `decided <https://github.com/unicef/magicbox-aggregate-mobility/issues/11>`_ to select Travis CI for our repos. Below is how you are going to add this service to a repo:
 
-2. If you are *not* on Travis CI yet, browse to `travis-ci.com <https://travis-ci.com/>`_ and log in with your GitHub account. Along the way, you will have the option to add any repo to Travis CI. Select "Only select repositories" and choose ``unicef/<the-repo-of-interest>`` from the drop-down list. **NOTE**: As of 07/2018, we still go by handpicking repos rather than adding every repo to Travis CI, although this policy might change in the future. Once you arrive at your Travis CI Profile page, you will see the list of all repos currently under Travis CI tracking (whether from your personal account or the unicef GitHub account).
+ #. Make sure you have the admin access to the repo. (New core developers can gain such access across multiple repos if `@mikefab <https://github.com/mikefab>`_ or one of the people in charge adds them to the `MagicBox Admins team <https://github.com/orgs/unicef/teams/magicbox-admins/members>`_.)
+ #. If you are *not* on Travis CI yet, browse to `travis-ci.com <https://travis-ci.com/>`_ and log in with your GitHub account. Along the way, you will have the option to add any repo to Travis CI. Select "Only select repositories" and choose ``unicef/<the-repo-of-interest>`` from the drop-down list. **NOTE**: As of 07/2018, we still go by handpicking repos rather than adding every repo to Travis CI, although this policy might change in the future. Once you arrive at your Travis CI Profile page, you will see the list of all repos currently under Travis CI tracking (whether from your personal account or the unicef GitHub account).
+ #. Now go to the repo's home page, click on the **Settings** tab, then select **Integrations & services** from the left-side menu. If everything is properly set up in the previous step, you should see Travis CI under the Installed GitHub Apps.
+ #. Go to the root directory of the repo and add a new file called ``.travis.yml``. Place the following content in that file:
 
-3. Now go to the repo's home page, click on the **Settings** tab, then select **Integrations & services** from the left-side menu. If everything is properly set up in the previous step, you should see Travis CI under the Installed GitHub Apps.
+  .. code-block:: javascript
 
-4. Go to the root directory of the repo and add a new file called ``.travis.yml``. Place the following content in that file:
-::
+   language: node_js
+   node_js:
+     - "8"
+   cache:
+     directories:
+       - "node_modules"
 
-  language: node_js
-  node_js:
-    - "8"
-  cache:
-    directories:
-      - "node_modules"
+  (If all of this doesn't make sense, use the following `Getting Started guide <https://docs.travis-ci.com/user/getting-started/>`_ by Travis CI.)
 
-(If all of this doesn't make sense, use the following `Getting Started guide <https://docs.travis-ci.com/user/getting-started/>`_ by Travis CI.)
-
-5. Last step is to add the Travis CI badge to the repo's README. Go to the Travis CI page of the repo - the URL probably looks like this: ``htps://travis-ci.com/unicef/the-repo-of-interest``. Find the status symbol (the little bar to the right of the Octocat) next to your repo's name. Click on it to generate the code block you'll put into your README, by selecting Markdown from the second dropdown menu when the Status Image window pops up (see the guide `here <https://docs.travis-ci.com/user/status-images/>`_).
-Copy the code snippet and place it on top of your repo's README file, just under the repo's name.
+ 5. Last step is to add the Travis CI badge to the repo's README. Go to the Travis CI page of the repo - the URL probably looks like this: ``htps://travis-ci.com/unicef/the-repo-of-interest``. Find the status symbol (the little bar to the right of the Octocat) next to your repo's name. Click on it to generate the code block you'll put into your README, by selecting Markdown from the second dropdown menu when the Status Image window pops up (see the guide `here <https://docs.travis-ci.com/user/status-images/>`_). Copy the code snippet and place it on top of your repo's README file, just under the repo's name.
 
 .. _set-up-code-health-checks:
 

--- a/docs/admin/github-workflow.rst
+++ b/docs/admin/github-workflow.rst
@@ -117,7 +117,7 @@ Every repository's issue and pull request labels are found under the *Issues* ta
 
    Click the *Labels* button towards the right of the search bar
 
-A good example of labels is `here <https://github.com/unicef/magicbox/labels>`_ on the `unicef/magicbox`_ repository. (To view the color code for a given label, click the "Edit" on its row.)
+A good example of labels is `here <https://github.com/unicef/magicbox/labels>`_ on the `unicef/magicbox`_ repository. (To view the color code for a given label, click the *Edit* on its row.)
 
 Not all of these labels will be helpful for a new project.
 Take ones that make sense, and make new labels specific to the project, if needed.
@@ -129,51 +129,134 @@ Set up continuous integration (CI)
 
 *FYI*: `Why we need CI <https://github.com/unicef/magicbox/issues/6>`_
 
-After his research, Justin (`@jwflory <https://github.com/jwflory>`_) - one of our former interns - `decided <https://github.com/unicef/magicbox-aggregate-mobility/issues/11>`_ to select `Travis CI <https://travis-ci.com/>`_ for our repos. Below is how you can add this service to a repo:
+After his research, Justin (`@jwflory <https://github.com/jwflory>`_) - one of our former interns - `decided <https://github.com/unicef/magicbox-aggregate-mobility/issues/11>`_ to select `Travis CI <https://travis-ci.com/>`_ for our repos.
+Below is how you can add this service to a repo:
 
- #. Make sure you have the admin access to the repo. (New core developers can gain such access across multiple repos if `@mikefab <https://github.com/mikefab>`_ or one of the people in charge adds them to the `MagicBox Admins team <https://github.com/orgs/unicef/teams/magicbox-admins/members>`_.)
- #. If you are *not* on Travis CI yet, browse to `travis-ci.com <https://travis-ci.com/>`_ and log in with your GitHub account. Along the way, you will have the option to add any repo to Travis CI. Select "Only select repositories" and choose ``unicef/<the-repo-of-interest>`` from the drop-down list. **NOTE**: As of 07/2018, we still go by handpicking repos rather than adding every repo to Travis CI, although this policy might change in the future. Once you arrive at your Travis CI Profile page, you will see the list of all repos currently under Travis CI tracking (whether from your personal account or the unicef GitHub account).
- #. Now go to the repo's home page, click on the **Settings** tab, then select **Integrations & services** from the left-side menu. If everything is properly set up in the previous step, you should see Travis CI under the Installed GitHub Apps.
- #. Go to the root directory of the repo and add a new file called ``.travis.yml``. Place the following content in that file:
+ 1. Make sure you have the **admin access** to the repo.
+ (New core developers can gain such access across multiple repos if `@mikefab <https://github.com/mikefab>`_ or one of the people in charge adds them to the `MagicBox Admins team <https://github.com/orgs/unicef/teams/magicbox-admins/members>`_.)
 
-  .. code-block:: javascript
+ 2. If you are not on Travis CI yet, browse to `travis-ci.com <https://travis-ci.com/>`_ and log in with your GitHub account.
+ Along the way, you will have the option to add any repo to Travis CI.
+ Select *Only select repositories* and choose ``unicef/<the-repo-of-interest>`` from the drop-down list.
+ **NOTE**: As of 07/2018, we still go by handpicking repos rather than adding every repo to Travis CI, although this policy might change in the future.
+ Once you arrive at your Travis CI Profile page, you will see the list of all repos currently under Travis CI tracking (whether from your personal account or the *unicef* GitHub account).
 
-   language: node_js
-   node_js:
-     - "8"
-   cache:
-     directories:
-       - "node_modules"
+ 3. Now go to the repo's home page, click on the *Settings* tab, then select *Integrations & services* from the left-side menu.
+ If everything is properly set up in the previous step, you should see Travis CI under *Installed GitHub Apps*.
 
-  (If all of this doesn't make sense, use the following `Getting Started guide <https://docs.travis-ci.com/user/getting-started/>`_ by Travis CI.)
+ 4. Go to the root directory of the repo and add a new file called ``.travis.yml``.
+ Place the following content in that file:
 
- 5. The last step is to add the Travis CI badge to the repo's README. Go to the Travis CI page of the repo - the URL probably looks like this: ``htps://travis-ci.com/unicef/the-repo-of-interest``. Find the status symbol next to your repo's name (the little bar to the right of the Octocat). Click on it to generate the code block you'll put into your README, by selecting Markdown from the second dropdown menu when the Status Image window pops up (see the guide `here <https://docs.travis-ci.com/user/status-images/>`_). Copy the code snippet and place it on top of your repo's README file, just under the repo's name.
+ .. code-block:: javascript
+
+  language: node_js
+  node_js:
+    - "8"
+  cache:
+    directories:
+      - "node_modules"
+
+ (If all of this doesn't make sense, use the following `Getting Started guide <https://docs.travis-ci.com/user/getting-started/>`_ by Travis CI.)
+
+ 5. The last step is to add the Travis CI badge to the repo's README.
+ Go to the Travis CI page of the repo - the URL probably looks like this: ``htps://travis-ci.com/unicef/the-repo-of-interest``.
+ Find the status symbol next to your repo's name (the little bar to the right of the Octocat).
+ Click on it to generate the code block you'll put into your README, by selecting Markdown from the second dropdown menu when the Status Image window pops up (if unclear, see `this guide <https://docs.travis-ci.com/user/status-images/>`_).
+ Copy the code snippet and place it on top of your repo's README file, just under the repo's name.
 
 .. _set-up-code-health-checks:
 
-Set up code health checks with CodeClimate
-==========================================
+Set up code health checks with Code Climate
+============================================
 
-We use `Code Climate <https://codeclimate.com/>`_ for our projects. This automated code review service runs checks whenever a pull request is made, helping contributors and maintainers identify issues before they get merged into the code base. While Travis CI  also provides pre-merge checks, the analysis provided by Code Climate is less about whether or not the program will break and more about how maintainable and "clean" the code is - hence the term "code health." Examples of issues that Code Climate will bring up: code is too complex/hard to read and understand; code is duplicated; a function or a class is too long and should be refactored; issues raised by ESLint. Aside from that, Code Climate also scores test coverage. Having high test coverage means the code in that particular repo is of high quality.
+We use `Code Climate <https://codeclimate.com/>`_ for our projects.
+This automated code review service runs checks whenever a pull request is made, helping contributors and maintainers identify issues before they get merged into the code base.
+While Travis CI  also provides pre-merge checks, the analysis provided by Code Climate is less about whether or not the program will break and more about how maintainable and "clean" the code is - hence the term "code health."
+Examples of issues that Code Climate will bring up: code is too complex/hard to read and understand; code is duplicated; a function or a class is too long and should be refactored; issues raised by ESLint.
+Aside from that, Code Climate also scores test coverage.
+Having high test coverage means the code in that particular repo is of high quality.
 
-Below is how you can add this service to a repo:
+Below is how you can add this service to a repo - make sure to gain **admin access** first.
 
-#. Similar to setting up Travis CI, you need admin access to carry out this task.
-#. Sign into `Code Climate - Quality <https://codeclimate.com/dashboard>`_ if you're not on it yet. If it's your first time signing up, use your GitHub account. (If you already have a Code Climate account and it is not linked with your GitHub account, follow `this guide <https://docs.codeclimate.com/docs/linkingunlinking-my-github-user>`_.) Select Open Source as you sign up and you can add the repo(s) here. Handpick repos rather than opting for "All repositories." If you're already landing on your Code Climate dashboard, then you can always add new repos by clicking on the button "Add a repository."
-#. Now Code Climate has started tracking your code. But you need a bit more set-up in order to interact with this service more actively. From the list of tracked repos on your Code Climate page, click the repo you want to set up, navigate to its Repo Settings tab, and follow this guide: https://docs.codeclimate.com/docs/workflow ... *Go to the repo home page, click "Settings" tab > select "Integrations & services" from the left-side menu, then add .... Then select the "Webhooks" tab, add a new webhook using the webhook URL.*
-#. We are not done yet since we also want test coverage scoring. Follow this guide to enable Test Coverage: https://docs.codeclimate.com/docs/getting-started-test-coverage
+ 1. Sign into `Code Climate - Quality <https://codeclimate.com/dashboard>`_ if you're not on it yet.
+ If it's your first time signing up, use your GitHub account.
+ (If you already have a Code Climate account and it is not **linked with your GitHub account**, follow `these instructions <https://docs.codeclimate.com/docs/linkingunlinking-my-github-user>`_ to set that up.)
+ Select *Open Source* as you sign up and you can add the repo(s) here.
+ Handpick repos rather than opting for *All repositories*."
+ If you're already landing on your Code Climate dashboard, then you can always add new repos by clicking on the button *Add a repository*.
 
-(if all of this doesn't make sense, use the guide from CodeClimate here: )
+ 2. Now Code Climate has started tracking your code, but you need a bit more set-up in order to interact with this service more actively.
+ From the list of tracked repos on your Code Climate page, click the repo you want to set up, navigate to its *Repo Settings* tab, and follow this guide: https://docs.codeclimate.com/docs/workflow ...
+
+  a. **Configure Pull Request features**:
+  You will want to configure some Pull Request features. Use this guide: https://docs.codeclimate.com/docs/github-pull-requests
+
+  b. **Set up Webhooks**:
+  This `guide <https://docs.codeclimate.com/v1.0/docs/installing-code-climates-webhook>`_ explains why we need Webhooks and how to set it up.
+  *Go to the repo home page, click "Settings" tab > select "Integrations & services" from the left-side menu, then add .... Then select the "Webhooks" tab, add a new webhook using the webhook URL.*
+
+  c. **Enable ESLint with Code Climate**:
+  To enable ESLint, go to *Repo Settings* > *Plugins*, then check the box *ESLint*.
+  In addition, for repos that use non-traditional JavaScript syntax such as JSX or ES6, you will need an extra step because the ESLint engine by default only analyzes ``.js`` files.
+  Go to the root directory of the repo, add a new file called ``.codeclimate.yml`` with the following content:
+
+  .. code-block:: javascript
+
+   plugins:
+   eslint:
+     enabled: true
+     channel: "eslint-4"
+     config:
+       extensions:
+       - .js
+       - .jsx
+   nodesecurity:
+     enabled: true
+
+  In the code above, in addition to setting the newest ESLint release possible (channel 4, see more here: https://docs.codeclimate.com/docs/eslint), we specify the file extensions that we want ESLint to analyze.
+
+ 3. We are not done yet since we also want **test coverage reporting**.
+ Go to your repo on Code Climate and navigate to *Repo Settings* > *Test coverage*.
+ There you will find the reo's Test Reporter ID.
+ Copy that token to clipboard.
+ Then go to your repo's home page on GitHub.
+ Replace the content of ``.travis-ci.yml`` with the following:
+
+ .. code-block:: javascript
+
+  CC_REPORTER_ID: <your-token-here>
+
+  env:
+    global:
+      - CC_TEST_REPORTER_ID=<your-token-here>
+
+  language: node_js
+  node_js:
+    - "8"
+  cache:
+    directories:
+      - "node_modules"
+
+  before_script:
+    - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+    - chmod +x ./cc-test-reporter
+    - ./cc-test-reporter before-build
+  after_script:
+    - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+
+ Follow this guide to enable Test Coverage: https://docs.codeclimate.com/docs/getting-started-test-coverage
+
+ (if all of this doesn't make sense, use the guide from CodeClimate here: https://docs.codeclimate.com/docs/open-source-free#section-adding-an-oss-github-repo-to-code-climate)
 
 Read more here:
 
-- https://docs.codeclimate.com/docs/open-source-free
-- https://docs.codeclimate.com/docs/repository-settings
 - Enable these things: https://docs.codeclimate.com/docs/github-pull-requests
-- (important for me) https://docs.codeclimate.com/docs/configuring-your-analysis
+- If you don't have admin access to a repo but still want to track its detailed code health analysis, go to its README on GitHub, click on its Maintainability badge, and *star* it to add this repo to your Code Climate dashboard. If unclear, `see this guide <https://docs.codeclimate.com/docs/adding-an-oss-repo-to-your-dashboard#section-adding-an-oss-repo-to-your-dashboard>`_.
 
-#. Once that is done, go to your repo home page on GitHub to add the maintainability and test coverage badges. Here's how to do it:
-
+ 4. Once that is done, go to your repo home page on GitHub to add the maintainability and test coverage badges.
+ Here's how to do it:
+ Head to your repo on Code Climate and click on *Repo Settings* > *Badges*.
+ Select the format of your choice and copy that code snippet to the top of the repo's README, just under the repo's name. (This `guide <https://docs.codeclimate.com/docs/overview#section-badges>`_ has good screenshots to clarify this step.)
 
 ***********************************
 How to maintain a GitHub repository

--- a/docs/admin/github-workflow.rst
+++ b/docs/admin/github-workflow.rst
@@ -133,18 +133,18 @@ After his research, Justin (`@jwflory <https://github.com/jwflory>`_) - one of o
 Below is how you can add this service to a repo:
 
  1. Make sure you have the **admin access** to the repo.
- (New core developers can gain such access across multiple repos if `@mikefab <https://github.com/mikefab>`_ or one of the people in charge adds them to the `MagicBox Admins team <https://github.com/orgs/unicef/teams/magicbox-admins/members>`_.)
+ (New core developers can gain such access across multiple repositories if Mike (`@mikefab <https://github.com/mikefab>`_) or one of the people in charge adds them to the `MagicBox Admins team <https://github.com/orgs/unicef/teams/magicbox-admins/members>`_.)
 
  2. If you are not on Travis CI yet, browse to `travis-ci.com <https://travis-ci.com/>`_ and log in with your GitHub account.
- Along the way, you will have the option to add any repo to Travis CI.
+ Along the way, you will have the option to add any repository to Travis CI.
  Select *Only select repositories* and choose ``unicef/<the-repo-of-interest>`` from the drop-down list.
- **NOTE**: As of 07/2018, we still go by handpicking repos rather than adding every repo to Travis CI, although this policy might change in the future.
- Once you arrive at your Travis CI Profile page, you will see the list of all repos currently under Travis CI tracking (whether from your personal account or the *unicef* GitHub account).
+ **NOTE**: As of 07/2018, we still go by handpicking repositories rather than adding every repository to Travis CI, although this policy might change in the future.
+ Once you arrive at your Travis CI Profile page, you will see the list of all repositories currently under Travis CI tracking (whether from your personal account or the `@unicef <https://github.com/unicef>`_ GitHub account).
 
- 3. Now go to the repo's home page, click on the *Settings* tab, then select *Integrations & services* from the left-side menu.
+ 3. Now go to the repository's main page on GitHub, click on the *Settings* tab, then select *Integrations & services* from the left-side menu.
  If everything is properly set up in the previous step, you should see Travis CI under *Installed GitHub Apps*.
 
- 4. Go to the root directory of the repo and add a new file called ``.travis.yml``.
+ 4. Go to the root directory of the repository and add a new file called ``.travis.yml``.
  Place the following content in that file:
 
  .. code-block:: javascript
@@ -156,49 +156,58 @@ Below is how you can add this service to a repo:
     directories:
       - "node_modules"
 
- (If all of this doesn't make sense, use the following `Getting Started guide <https://docs.travis-ci.com/user/getting-started/>`_ by Travis CI.)
+ (If these steps do not make sense, refer to this `Getting Started guide <https://docs.travis-ci.com/user/getting-started/>`_ by Travis CI.)
 
- 5. The last step is to add the Travis CI badge to the repo's README.
- Go to the Travis CI page of the repo - the URL probably looks like this: ``htps://travis-ci.com/unicef/the-repo-of-interest``.
- Find the status symbol next to your repo's name (the little bar to the right of the Octocat).
+ 5. The last step is to add the Travis CI badge to the repository's README.
+ Go to the Travis CI page of the repository - the URL probably looks like this: ``htps://travis-ci.com/unicef/the-repo-of-interest``.
+ Find the status symbol next to your repository's name (the little bar to the right of the Octocat).
  Click on it to generate the code block you'll put into your README, by selecting Markdown from the second dropdown menu when the Status Image window pops up (if unclear, see `this guide <https://docs.travis-ci.com/user/status-images/>`_).
- Copy the code snippet and place it on top of your repo's README file, just under the repo's name.
+ Copy the code snippet and place it on top of your repository's README file, just under the repository's name.
 
 .. _set-up-code-health-checks:
 
 Set up code health checks with Code Climate
 ============================================
+=======
 
 We use `Code Climate <https://codeclimate.com/>`_ for our projects.
 This automated code review service runs checks whenever a pull request is made, helping contributors and maintainers identify issues before they get merged into the code base.
-While Travis CI  also provides pre-merge checks, the analysis provided by Code Climate is less about whether or not the program will break and more about how maintainable and "clean" the code is - hence the term "code health."
+While Travis CI also provides pre-merge checks, the analysis provided by Code Climate is less about whether or not the program will break and more about how maintainable and "clean" the code is - hence the term "code health."
 Examples of issues that Code Climate will bring up: code is too complex/hard to read and understand; code is duplicated; a function or a class is too long and should be refactored; issues raised by ESLint.
 Aside from that, Code Climate also scores test coverage.
-Having high test coverage means the code in that particular repo is of high quality.
+Having high test coverage means the code in that particular repository is of high quality.
 
-Below is how you can add this service to a repo - make sure to gain **admin access** first.
+Below is how you can add this service to a repository - make sure to gain **admin access** first.
 
  1. Sign into `Code Climate - Quality <https://codeclimate.com/dashboard>`_ if you're not on it yet.
  If it's your first time signing up, use your GitHub account.
  (If you already have a Code Climate account and it is not **linked with your GitHub account**, follow `these instructions <https://docs.codeclimate.com/docs/linkingunlinking-my-github-user>`_ to set that up.)
- Select *Open Source* as you sign up and you can add the repo(s) here.
- Handpick repos rather than opting for *All repositories*."
- If you're already landing on your Code Climate dashboard, then you can always add new repos by clicking on the button *Add a repository*.
+ Select *Open Source* as you sign up and you can add the repository here.
+ Handpick repositories rather than opting for *All repositories*.
+ If you're already landing on your Code Climate dashboard, then you can always add new repositories by clicking on the button *Add a repository*.
+ (If all of this doesn't make sense, use this `guide from CodeClimate <https://docs.codeclimate.com/docs/open-source-free#section-adding-an-oss-github-repo-to-code-climate>`_.)
 
  2. Now Code Climate has started tracking your code, but you need a bit more set-up in order to interact with this service more actively.
- From the list of tracked repos on your Code Climate page, click the repo you want to set up, navigate to its *Repo Settings* tab, and follow this guide: https://docs.codeclimate.com/docs/workflow ...
+ From the list of tracked repositories on your Code Climate profile, click the repository you want to set up and navigate to its *Repo Settings* tab. Look for the following sections in the left-side navigation menu.
 
-  a. **Configure Pull Request features**:
-  You will want to configure some Pull Request features. Use this guide: https://docs.codeclimate.com/docs/github-pull-requests
+  a. **Enable Pull Request integration**:
+  *GitHub* section.
+  Scroll down to *Pull request status updates* and click *Install*.
+  A little green check mark will tell you if the installation succeeds and this feature is now active.
+  If this option is not available or nowhere to be seen, it could be because you have not installed the Code Climate GitHub app.
+  In step 1, by signing up and linking your GitHub account, you have connected with Code Climate via OAuth authentication.
+  Your GitHub repository now sees Code Climate as an OAuth app.
+  However, for Code Climate to automatically display the check status at each pull request, Code Climate needs to have access to your GitHub repository as a GitHub app.
+  Hence, head to `Code Climate GitHub app <https://github.com/apps/codeclimate>`_ to install it on *both* your personal account and the `@unicef <https://github.com/unicef>`_ GitHub account. You should install it on your personal account to utilize Code Climate power when you work in your own forks.
 
   b. **Set up Webhooks**:
   This `guide <https://docs.codeclimate.com/v1.0/docs/installing-code-climates-webhook>`_ explains why we need Webhooks and how to set it up.
-  *Go to the repo home page, click "Settings" tab > select "Integrations & services" from the left-side menu, then add .... Then select the "Webhooks" tab, add a new webhook using the webhook URL.*
+  You can verify if the setup is successful via either Code Climate (*Repo Settings* > *GitHub* > *Connections* > *Webhook on GitHub*) or GitHub (*Settings* > *Webhooks*).
 
   c. **Enable ESLint with Code Climate**:
-  To enable ESLint, go to *Repo Settings* > *Plugins*, then check the box *ESLint*.
-  In addition, for repos that use non-traditional JavaScript syntax such as JSX or ES6, you will need an extra step because the ESLint engine by default only analyzes ``.js`` files.
-  Go to the root directory of the repo, add a new file called ``.codeclimate.yml`` with the following content:
+  *Plugins* section.
+  Check the box in front of *ESLint*.
+  Since the ESLint engine by default only analyzes ``.js`` files, if the repository uses non-traditional JavaScript syntax such as JSX or ES6, you will need to add the following file to the repository's root directory. Name it ``.codeclimate.yml``:
 
   .. code-block:: javascript
 
@@ -213,18 +222,18 @@ Below is how you can add this service to a repo - make sure to gain **admin acce
    nodesecurity:
      enabled: true
 
-  In the code above, in addition to setting the newest ESLint release possible (channel 4, see more here: https://docs.codeclimate.com/docs/eslint), we specify the file extensions that we want ESLint to analyze.
+  This code, in addition to accessing the newest ESLint release possible (channel 4, see more here: https://docs.codeclimate.com/docs/eslint), specifies the file extensions that we want ESLint to analyze.
 
  3. We are not done yet since we also want **test coverage reporting**.
- Go to your repo on Code Climate and navigate to *Repo Settings* > *Test coverage*.
- There you will find the reo's Test Reporter ID.
+ As said in point number 7 `here <https://docs.codeclimate.com/docs/github-pull-requests#section-show-me-how>`_, test coverage statuses are enabled by default when you enable Pull Request integration.
+ However, the docs article also says you need to configure test coverage for the statuses to populate.
+ Hence, go to your repository on Code Climate and navigate to *Repo Settings* > *Test coverage*.
+ There you will find the repository's Test Reporter ID.
  Copy that token to clipboard.
- Then go to your repo's home page on GitHub.
+ Then go to your repository's main page on GitHub.
  Replace the content of ``.travis-ci.yml`` with the following:
 
  .. code-block:: javascript
-
-  CC_REPORTER_ID: <your-token-here>
 
   env:
     global:
@@ -244,19 +253,17 @@ Below is how you can add this service to a repo - make sure to gain **admin acce
   after_script:
     - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
- Follow this guide to enable Test Coverage: https://docs.codeclimate.com/docs/getting-started-test-coverage
+Deeper reads:
 
- (if all of this doesn't make sense, use the guide from CodeClimate here: https://docs.codeclimate.com/docs/open-source-free#section-adding-an-oss-github-repo-to-code-climate)
+- If you don't have admin access to a repository but still want to track its detailed code health analysis, go to its README on GitHub, click on its Maintainability badge to open its Code Climate report, and hit *Star* to add this repository to your Code Climate dashboard. If unclear, `see this guide <https://docs.codeclimate.com/docs/adding-an-oss-repo-to-your-dashboard#section-adding-an-oss-repo-to-your-dashboard>`_.
 
-Read more here:
+- If you are a core developer or maintainer, read this article to make better use of Code Climate in your pull request workflow: https://docs.codeclimate.com/docs/workflow
 
-- Enable these things: https://docs.codeclimate.com/docs/github-pull-requests
-- If you don't have admin access to a repo but still want to track its detailed code health analysis, go to its README on GitHub, click on its Maintainability badge, and *star* it to add this repo to your Code Climate dashboard. If unclear, `see this guide <https://docs.codeclimate.com/docs/adding-an-oss-repo-to-your-dashboard#section-adding-an-oss-repo-to-your-dashboard>`_.
+- Advanced features with *review comments*: https://docs.codeclimate.com/docs/github-pull-requests#section-pull-request-review-comments
 
- 4. Once that is done, go to your repo home page on GitHub to add the maintainability and test coverage badges.
- Here's how to do it:
- Head to your repo on Code Climate and click on *Repo Settings* > *Badges*.
- Select the format of your choice and copy that code snippet to the top of the repo's README, just under the repo's name. (This `guide <https://docs.codeclimate.com/docs/overview#section-badges>`_ has good screenshots to clarify this step.)
+ 4. The last step is to embed the **maintainability and test coverage badges** to GitHub.
+ Head to your repository on Code Climate and click on *Repo Settings* > *Badges*.
+ Select the format of your choice and copy that code snippet to the top of the repository's README, just under the repository's name. (This `guide <https://docs.codeclimate.com/docs/overview#section-badges>`_ has good screenshots to illustrate this step.)
 
 ***********************************
 How to maintain a GitHub repository

--- a/docs/admin/github-workflow.rst
+++ b/docs/admin/github-workflow.rst
@@ -127,7 +127,9 @@ Take ones that make sense, and make new labels specific to the project, if neede
 Set up continuous integration (CI)
 ==================================
 
-After his research, `@jwflory <https://github.com/jwflory>`_ - one of our former interns - `decided <https://github.com/unicef/magicbox-aggregate-mobility/issues/11>`_ to select Travis CI for our repos. Below is how you are going to add this service to a repo:
+*FYI*: `Why we need CI <https://github.com/unicef/magicbox/issues/6>`_
+
+After his research, Justin (`@jwflory <https://github.com/jwflory>`_) - one of our former interns - `decided <https://github.com/unicef/magicbox-aggregate-mobility/issues/11>`_ to select `Travis CI <https://travis-ci.com/>`_ for our repos. Below is how you can add this service to a repo:
 
  #. Make sure you have the admin access to the repo. (New core developers can gain such access across multiple repos if `@mikefab <https://github.com/mikefab>`_ or one of the people in charge adds them to the `MagicBox Admins team <https://github.com/orgs/unicef/teams/magicbox-admins/members>`_.)
  #. If you are *not* on Travis CI yet, browse to `travis-ci.com <https://travis-ci.com/>`_ and log in with your GitHub account. Along the way, you will have the option to add any repo to Travis CI. Select "Only select repositories" and choose ``unicef/<the-repo-of-interest>`` from the drop-down list. **NOTE**: As of 07/2018, we still go by handpicking repos rather than adding every repo to Travis CI, although this policy might change in the future. Once you arrive at your Travis CI Profile page, you will see the list of all repos currently under Travis CI tracking (whether from your personal account or the unicef GitHub account).
@@ -145,19 +147,33 @@ After his research, `@jwflory <https://github.com/jwflory>`_ - one of our former
 
   (If all of this doesn't make sense, use the following `Getting Started guide <https://docs.travis-ci.com/user/getting-started/>`_ by Travis CI.)
 
- 5. Last step is to add the Travis CI badge to the repo's README. Go to the Travis CI page of the repo - the URL probably looks like this: ``htps://travis-ci.com/unicef/the-repo-of-interest``. Find the status symbol (the little bar to the right of the Octocat) next to your repo's name. Click on it to generate the code block you'll put into your README, by selecting Markdown from the second dropdown menu when the Status Image window pops up (see the guide `here <https://docs.travis-ci.com/user/status-images/>`_). Copy the code snippet and place it on top of your repo's README file, just under the repo's name.
+ 5. The last step is to add the Travis CI badge to the repo's README. Go to the Travis CI page of the repo - the URL probably looks like this: ``htps://travis-ci.com/unicef/the-repo-of-interest``. Find the status symbol next to your repo's name (the little bar to the right of the Octocat). Click on it to generate the code block you'll put into your README, by selecting Markdown from the second dropdown menu when the Status Image window pops up (see the guide `here <https://docs.travis-ci.com/user/status-images/>`_). Copy the code snippet and place it on top of your repo's README file, just under the repo's name.
 
 .. _set-up-code-health-checks:
 
 Set up code health checks with CodeClimate
 ==========================================
 
-We use CodeClimate for our projects. What this does is that ... Below is how you are going to add this service to a repo:
-   - Similar to above, you need admin access to carry out this task.
-   - Go to the repo home page, click "Settings" tab > select "Integrations & services" from the left-side menu, then add .... Then select the "Webhooks" tab, add a new webhook using the webhook URL.
+We use `Code Climate <https://codeclimate.com/>`_ for our projects. This automated code review service runs checks whenever a pull request is made, helping contributors and maintainers identify issues before they get merged into the code base. While Travis CI  also provides pre-merge checks, the analysis provided by Code Climate is less about whether or not the program will break and more about how maintainable and "clean" the code is - hence the term "code health." Examples of issues that Code Climate will bring up: code is too complex/hard to read and understand; code is duplicated; a function or a class is too long and should be refactored; issues raised by ESLint. Aside from that, Code Climate also scores test coverage. Having high test coverage means the code in that particular repo is of high quality.
+
+Below is how you can add this service to a repo:
+
+#. Similar to setting up Travis CI, you need admin access to carry out this task.
+#. Sign into `Code Climate - Quality <https://codeclimate.com/dashboard>`_ if you're not on it yet. If it's your first time signing up, use your GitHub account. (If you already have a Code Climate account and it is not linked with your GitHub account, follow `this guide <https://docs.codeclimate.com/docs/linkingunlinking-my-github-user>`_.) Select Open Source as you sign up and you can add the repo(s) here. Handpick repos rather than opting for "All repositories." If you're already landing on your Code Climate dashboard, then you can always add new repos by clicking on the button "Add a repository."
+#. Now Code Climate has started tracking your code. But you need a bit more set-up in order to interact with this service more actively. From the list of tracked repos on your Code Climate page, click the repo you want to set up, navigate to its Repo Settings tab, and follow this guide: https://docs.codeclimate.com/docs/workflow ... *Go to the repo home page, click "Settings" tab > select "Integrations & services" from the left-side menu, then add .... Then select the "Webhooks" tab, add a new webhook using the webhook URL.*
+#. We are not done yet since we also want test coverage scoring. Follow this guide to enable Test Coverage: https://docs.codeclimate.com/docs/getting-started-test-coverage
+
 (if all of this doesn't make sense, use the guide from CodeClimate here: )
-   - Enable/Configure the Test Coverage service: ...
-   - Add the Maintainability and the Test Coverage badges to the repo's README: ...
+
+Read more here:
+
+- https://docs.codeclimate.com/docs/open-source-free
+- https://docs.codeclimate.com/docs/repository-settings
+- Enable these things: https://docs.codeclimate.com/docs/github-pull-requests
+- (important for me) https://docs.codeclimate.com/docs/configuring-your-analysis
+
+#. Once that is done, go to your repo home page on GitHub to add the maintainability and test coverage badges. Here's how to do it:
+
 
 ***********************************
 How to maintain a GitHub repository

--- a/docs/admin/github-workflow.rst
+++ b/docs/admin/github-workflow.rst
@@ -127,15 +127,35 @@ Take ones that make sense, and make new labels specific to the project, if neede
 Set up continuous integration (CI)
 ==================================
 
-.. note:: To be written.
+After his research, @jwflory - one of our former interns - [decided](https://github.com/unicef/magicbox-aggregate-mobility/issues/11) to select Travis CI for our repos. Below is how you are going to add this service to a repo:
+1. Make sure you have the admin access to the repo. (New core developers can gain such access across multiple repos if @mikefab or one of the people in charge adds them to the [MagicBox Admins team](https://github.com/orgs/unicef/teams/magicbox-admins/members).)
+2. If you are _not_ on Travis CI yet, browse to travis-ci.com and log in with your GitHub account. Along the way, you will have the option to add any repo to Travis CI. Select "Only select repositories" and choose `unicef/<the-repo-of-interest>` from the drop-down list. **NOTE**: As of 07/2018, we still go by handpicking repos rather than adding every repo to Travis CI, although this policy might change in the future. Once you arrive at your Travis CI Profile page, you will see the list of all repos (whether from your personal account or the unicef GitHub account) under Travis CI tracking.
+3. Now go to the repo's home page, click on the **Settings** tab, then select **Integrations & services** from the left-side menu. If everything is properly set up in the previous step, you should see Travis CI under the Installed GitHub Apps.
+4. Go to the root directory of the repo and add a new file called `.travis.yml`. Place the following content in that file:
+```
+language: node_js
+node_js:
+  - "8"
+cache:
+  directories:
+    - "node_modules"
+```
+(If all of this doesn't make sense, use the following [Getting Started guide](https://docs.travis-ci.com/user/getting-started/) by Travis CI).
+5. Last step: add the Travis CI badge to the repo's README: go to the Travis CI page of the repo - the URL probably looks like this: `htps://travis-ci.com/unicef/the-repo-of-interest`. Find the status symbol (the bar to the right of the Octocat) next to your repo's name. Click on it to generate the code block you'll put into your README, by selecting Markdown from the second dropdown menu when the Status Image window pops up (see the guide [here](https://docs.travis-ci.com/user/status-images/)).
+Copy the code snippet and place it on top of your repo's README file, just under the repo's name.
 
 .. _set-up-code-health-checks:
 
 Set up code health checks with CodeClimate
 ==========================================
 
-.. note:: To be written.
-
+- Set up Code health checks:
+We use CodeClimate for our projects. What this does is that ... Below is how you are going to add this service to a repo:
+   - Similar to above, you need admin access to carry out this task.
+   - Go to the repo home page, click "Settings" tab > select "Integrations & services" from the left-side menu, then add .... Then select the "Webhooks" tab, add a new webhook using the webhook URL.
+(if all of this doesn't make sense, use the guide from CodeClimate here: )
+   - Enable/Configure the Test Coverage service: ...
+   - Add the Maintainability and the Test Coverage badges to the repo's README: ...
 
 ***********************************
 How to maintain a GitHub repository

--- a/docs/admin/github-workflow.rst
+++ b/docs/admin/github-workflow.rst
@@ -78,7 +78,7 @@ Make sure every repository has a description and topic tags set.
 If there is a URL to view a demo of the project or read more about it, include it too.
 
 At the top of every GitHub repository, there are fields of metadata for a description, a URL, and topic tags.
-A description and URL helps someone understand tge project in one or two sentences or see a live demo.
+A description and URL helps someone understand the project in one or two sentences or see a live demo.
 Topic tags raise visibility in the GitHub ecosystem and help other people discover new projects.
 
 .. figure:: /_static/github-workflow-description-tags-empty.png
@@ -117,7 +117,7 @@ Every repository's issue and pull request labels are found under the *Issues* ta
 
    Click the *Labels* button towards the right of the search bar
 
-A good example of labels is `here <https://github.com/unicef/magicbox/labels>`_ on the `unicef/magicbox`_ repository. (To view the color code for a given label, click the *Edit* on its row.)
+A good example of labels is `here <https://github.com/unicef/magicbox/labels>`_ on the `unicef/magicbox`_ repository. To view the color code for a given label, click the *Edit* on its row.
 
 Not all of these labels will be helpful for a new project.
 Take ones that make sense, and make new labels specific to the project, if needed.
@@ -127,7 +127,7 @@ Take ones that make sense, and make new labels specific to the project, if neede
 Set up continuous integration (CI)
 ==================================
 
-*FYI*: `Why we need CI <https://github.com/unicef/magicbox/issues/6>`_
+- `Why we need CI <https://github.com/unicef/magicbox/issues/6>`_
 
 After his research, Justin (`@jwflory <https://github.com/jwflory>`_) - one of our former interns - `decided <https://github.com/unicef/magicbox-aggregate-mobility/issues/11>`_ to select `Travis CI <https://travis-ci.com/>`_ for our repos.
 Below is how you can add this service to a repo:

--- a/docs/admin/github-workflow.rst
+++ b/docs/admin/github-workflow.rst
@@ -171,7 +171,6 @@ Below is how you can add this service to a new repository:
 
 Set up code health checks with Code Climate
 ============================================
-=======
 
 `Code Climate <https://codeclimate.com/>`_ is the chosen code health checker for MagicBox projects.
 This automated code review service runs checks whenever a pull request is made, helping contributors and maintainers identify issues before they get merged into the code base.

--- a/docs/admin/github-workflow.rst
+++ b/docs/admin/github-workflow.rst
@@ -126,22 +126,27 @@ Take ones that make sense, and make new labels specific to the project, if neede
 
 Set up continuous integration (CI)
 ==================================
+After his research, @jwflory - one of our former interns - `decided <https://github.com/unicef/magicbox-aggregate-mobility/issues/11>`_ to select Travis CI for our repos. Below is how you are going to add this service to a repo:
 
-After his research, @jwflory - one of our former interns - [decided](https://github.com/unicef/magicbox-aggregate-mobility/issues/11) to select Travis CI for our repos. Below is how you are going to add this service to a repo:
-1. Make sure you have the admin access to the repo. (New core developers can gain such access across multiple repos if @mikefab or one of the people in charge adds them to the [MagicBox Admins team](https://github.com/orgs/unicef/teams/magicbox-admins/members).)
-2. If you are _not_ on Travis CI yet, browse to travis-ci.com and log in with your GitHub account. Along the way, you will have the option to add any repo to Travis CI. Select "Only select repositories" and choose `unicef/<the-repo-of-interest>` from the drop-down list. **NOTE**: As of 07/2018, we still go by handpicking repos rather than adding every repo to Travis CI, although this policy might change in the future. Once you arrive at your Travis CI Profile page, you will see the list of all repos (whether from your personal account or the unicef GitHub account) under Travis CI tracking.
+1. Make sure you have the admin access to the repo. (New core developers can gain such access across multiple repos if @mikefab or one of the people in charge adds them to the `MagicBox Admins team <https://github.com/orgs/unicef/teams/magicbox-admins/members>`_.)
+
+2. If you are *not* on Travis CI yet, browse to `travis-ci.com <https://travis-ci.com/>`_ and log in with your GitHub account. Along the way, you will have the option to add any repo to Travis CI. Select "Only select repositories" and choose ``unicef/<the-repo-of-interest>`` from the drop-down list. **NOTE**: As of 07/2018, we still go by handpicking repos rather than adding every repo to Travis CI, although this policy might change in the future. Once you arrive at your Travis CI Profile page, you will see the list of all repos currently under Travis CI tracking (whether from your personal account or the unicef GitHub account).
+
 3. Now go to the repo's home page, click on the **Settings** tab, then select **Integrations & services** from the left-side menu. If everything is properly set up in the previous step, you should see Travis CI under the Installed GitHub Apps.
-4. Go to the root directory of the repo and add a new file called `.travis.yml`. Place the following content in that file:
-```
-language: node_js
-node_js:
-  - "8"
-cache:
-  directories:
-    - "node_modules"
-```
-(If all of this doesn't make sense, use the following [Getting Started guide](https://docs.travis-ci.com/user/getting-started/) by Travis CI).
-5. Last step: add the Travis CI badge to the repo's README: go to the Travis CI page of the repo - the URL probably looks like this: `htps://travis-ci.com/unicef/the-repo-of-interest`. Find the status symbol (the bar to the right of the Octocat) next to your repo's name. Click on it to generate the code block you'll put into your README, by selecting Markdown from the second dropdown menu when the Status Image window pops up (see the guide [here](https://docs.travis-ci.com/user/status-images/)).
+
+4. Go to the root directory of the repo and add a new file called ``.travis.yml``. Place the following content in that file:
+::
+
+  language: node_js
+  node_js:
+    - "8"
+  cache:
+    directories:
+      - "node_modules"
+
+(If all of this doesn't make sense, use the following `Getting Started guide <https://docs.travis-ci.com/user/getting-started/>`_ by Travis CI.)
+
+5. Last step is to add the Travis CI badge to the repo's README. Go to the Travis CI page of the repo - the URL probably looks like this: ``htps://travis-ci.com/unicef/the-repo-of-interest``. Find the status symbol (the little bar to the right of the Octocat) next to your repo's name. Click on it to generate the code block you'll put into your README, by selecting Markdown from the second dropdown menu when the Status Image window pops up (see the guide `here <https://docs.travis-ci.com/user/status-images/>`_).
 Copy the code snippet and place it on top of your repo's README file, just under the repo's name.
 
 .. _set-up-code-health-checks:
@@ -149,7 +154,6 @@ Copy the code snippet and place it on top of your repo's README file, just under
 Set up code health checks with CodeClimate
 ==========================================
 
-- Set up Code health checks:
 We use CodeClimate for our projects. What this does is that ... Below is how you are going to add this service to a repo:
    - Similar to above, you need admin access to carry out this task.
    - Go to the repo home page, click "Settings" tab > select "Integrations & services" from the left-side menu, then add .... Then select the "Webhooks" tab, add a new webhook using the webhook URL.


### PR DESCRIPTION
As suggested by @jwflory [here](https://github.com/unicef/magicbox-maps-prototype/issues/10), I started a draft to fill in [two sections](https://magicbox.readthedocs.io/en/latest/admin/github-workflow.html#set-up-continuous-integration-ci) in the GitHub Workflow article for our ReadTheDocs:

- Set up continuous integration
- Set up code health checks with CodeClimate

This is still a work in progress but @jwflory and everyone feels free to jump in if you find certain sentences too complicated to read or some procedures just plain wrong. 

I hope to finish this either by the end of this week (Jul 9-13) or early next week (Jul 16-20).

